### PR TITLE
Add min_length threshold for feed articles

### DIFF
--- a/news/models.py
+++ b/news/models.py
@@ -127,6 +127,7 @@ class Feeds(models.Model):
     script = models.TextField(blank=True, null=True)  # noqa: DJ001
     frequency = models.TextField(blank=True, null=True)  # noqa: DJ001
     tags = ArrayField(models.TextField(), blank=True, null=True)
+    min_length = models.IntegerField(blank=True, null=True)
 
     class Meta:
         managed = False
@@ -150,6 +151,7 @@ class FeedPolling(models.Model):
     articles_retrieved = models.IntegerField()
     articles_failed = models.IntegerField()
     articles_stored = models.IntegerField()
+    articles_skipped = models.IntegerField(default=0)
 
     class Meta:
         managed = True

--- a/news/poll_119.py
+++ b/news/poll_119.py
@@ -65,6 +65,7 @@ data["non_articles"] = 0
 data["retrieved"] = 0
 data["failed"] = 0
 data["stored"] = 0
+data["skipped"] = 0
 for e in entries:
     logger.info(f"== to retrieve: {e}")
     html = requests.get(e, cookies=cj, headers=headers, timeout=30).text
@@ -96,9 +97,9 @@ for e in entries:
             content += c1
         logger.info(f"=== {content[:100]}")
 
-        MIN_CONTENT_LENGTH = 50
+        min_length = feed.min_length if feed.min_length is not None else 50
 
-        if len(content) > MIN_CONTENT_LENGTH:
+        if len(content) > min_length:
             res = poller.store_article(
                 author=author,
                 title=title,
@@ -121,7 +122,7 @@ for e in entries:
             sys.stdout.write("\n")
         else:
             logger.info(f"=== skipping because length = {len(content)}")
-            data["failed"] += 1
+            data["skipped"] += 1
     except IndexError:
         logger.exception("=== skipping because could not find required keys")
         data["failed"] += 1
@@ -135,4 +136,6 @@ rewire.rewire_article(id0)
 feed.last_polled = datetime.datetime.now(datetime.UTC)
 feed.save()
 
-logger.info(f"== done: {data["retrieved"]} {data["failed"]} {data["stored"]}")
+logger.info(
+    f"== done: {data['retrieved']} {data['failed']} {data['stored']} {data['skipped']}",
+)

--- a/news/poll_94.py
+++ b/news/poll_94.py
@@ -38,7 +38,6 @@ headers = {
 }
 
 feed_id = 94
-length_threshold = 2000  # minimum acceptable length for an article
 language = "it"
 
 feed = Feeds.objects.filter(id=feed_id).first()
@@ -60,7 +59,9 @@ data = {
     "retrieved": 0,
     "failed": 0,
     "stored": 0,
+    "skipped": 0,
 }
+length_threshold = feed.min_length if feed.min_length is not None else 2000
 if len(content) > length_threshold:
     data["retrieved"] = 1
     res = poller.store_article(
@@ -77,10 +78,12 @@ if len(content) > length_threshold:
     else:
         data["failed"] = 1
 else:
-    data["failed"] = 1
+    data["skipped"] = 1
     logger.error(f"=== skipping because lenght = {len(content)}")
 
 feed.last_polled = datetime.datetime.now(datetime.UTC)
 feed.save()
 
-logger.info(f"== done: {data["retrieved"]} {data["failed"]} {data["stored"]}")
+logger.info(
+    f"== done: {data['retrieved']} {data['failed']} {data['stored']} {data['skipped']}",
+)

--- a/news/poll_96.py
+++ b/news/poll_96.py
@@ -22,7 +22,6 @@ logger.info("== entering")
 
 base_url = "https://rep.repubblica.it/ws/cover.json"
 feed_id = 96
-length_threshold = 500  # minimum acceptable length for an article
 language = "it"
 
 feed = Feeds.objects.filter(id=feed_id).first()
@@ -66,6 +65,7 @@ data["non_articles"] = 0
 data["retrieved"] = 0
 data["failed"] = 0
 data["stored"] = 0
+data["skipped"] = 0
 for e in entries:
     logger.info(f"=== retrieving: {e["url"]}")
     html = requests.get(e["url"], cookies=cj, headers=headers, timeout=30).text
@@ -87,6 +87,7 @@ for e in entries:
         content += b.prettify()
     if isinstance(content, bytes):
         content = content.decode()
+    length_threshold = feed.min_length if feed.min_length is not None else 500
     if len(content) > length_threshold:
         updated_dt += datetime.timedelta(seconds=1)
         res = poller.store_article(
@@ -111,9 +112,11 @@ for e in entries:
         sys.stdout.write("\n")
     else:
         logger.error(f"=== skipping because lenght = {len(content)}")
-        data["failed"] += 1
+        data["skipped"] += 1
 
 feed.last_polled = datetime.datetime.now(datetime.UTC)
 feed.save()
 
-logger.info(f"== done: {data["retrieved"]} {data["failed"]} {data["stored"]}")
+logger.info(
+    f"== done: {data['retrieved']} {data['failed']} {data['stored']} {data['skipped']}",
+)

--- a/poller.py
+++ b/poller.py
@@ -105,10 +105,11 @@ async def retrieve(
     feed: Any,
     *,
     verbose: bool,
-) -> tuple[int, int, int]:
+) -> tuple[int, int, int, int]:
     retrieved = 0
     failed = 0
     stored = 0
+    skipped = 0
     url = entry["link"]
     if feed.incomplete and entry["link"]:
         content, retrieved, failed = await download_content(
@@ -126,7 +127,7 @@ async def retrieve(
     else:
         failed += 1
         logger.error(f"=== url {url} has no content and no summary")
-        return (retrieved, failed, stored)
+        return (retrieved, failed, stored, skipped)
 
     decoded_content = content.decode() if isinstance(content, bytes) else content
 
@@ -140,6 +141,15 @@ async def retrieve(
         )
         author = clean(entry.get("author", "anonimo"))
         normalized_content = normalize_content(decoded_content, base_url, feed.exclude)
+
+        if feed.min_length and len(normalized_content) < feed.min_length:
+            skipped += 1
+            if verbose:
+                logger.info(
+                    f"=== skipping {entry['link']} because length {len(normalized_content)} < {feed.min_length}",  # noqa: E501
+                )
+            return (retrieved, failed, stored, skipped)
+
         title = clean(entry.get("title", ""))
         article: ArticleDict = {
             "author": author,
@@ -159,7 +169,7 @@ async def retrieve(
                 )
         elif article_id < 0:
             failed += 1
-    return (retrieved, failed, stored)
+    return (retrieved, failed, stored, skipped)
 
 
 async def main(
@@ -168,7 +178,7 @@ async def main(
     feed: Any,
     *,
     verbose: bool,
-) -> list[tuple[int, int, int]]:
+) -> list[tuple[int, int, int, int]]:
     cookies: dict[str, str] = {}
     if feed.cookies and feed.cookies != "":
         cookies_file = feed.cookies.replace("/srv/calo.news/", "/app/")
@@ -651,32 +661,33 @@ def _retrieve_and_process_entries(sorted_entries, feed, *, verbose=True):
         main(loop, sorted_entries, feed, verbose=verbose),
     )
 
-    retrieved, failed, stored = 0, 0, 0
+    retrieved, failed, stored, skipped = 0, 0, 0, 0
     for r_item in results:
         retrieved += r_item[0]
         failed += r_item[1]
         stored += r_item[2]
+        skipped += r_item[3]
 
-    return retrieved, failed, stored
+    return retrieved, failed, stored, skipped
 
 
 def _poll_feed(feed):
     verbose = True
 
     # Initialize variables that will be saved in FeedPoller
-    retrieved, failed, stored = 0, 0, 0
+    retrieved, failed, stored, skipped = 0, 0, 0, 0
 
     # Fetch feed response with error handling
     response, status_code = _fetch_feed_response(feed.url)
 
     # If response is None, return early with error status
     if not response:
-        return retrieved, failed, stored, status_code
+        return retrieved, failed, stored, skipped, status_code
 
     # Check for HTTP error status code
     if response.status_code != HTTP_SUCCESS_CODE:
         logger.error(f"== url {feed.url} returned error status {response.status_code}")
-        return retrieved, failed, stored, status_code
+        return retrieved, failed, stored, skipped, status_code
 
     # Parse feed content
     rss_feed = _parse_feed_content(feed, response)
@@ -685,13 +696,13 @@ def _poll_feed(feed):
     sorted_entries = _process_feed_entries(rss_feed["entries"], verbose=verbose)
 
     # Retrieve and process entries
-    retrieved, failed, stored = _retrieve_and_process_entries(
+    retrieved, failed, stored, skipped = _retrieve_and_process_entries(
         sorted_entries,
         feed,
         verbose=verbose,
     )
 
-    return retrieved, failed, stored, status_code
+    return retrieved, failed, stored, skipped, status_code
 
 
 class Poller:
@@ -699,6 +710,7 @@ class Poller:
         self.stored = 0
         self.retrieved = 0
         self.failed = 0
+        self.skipped = 0
         self.feed = feed
         self.p = None
 
@@ -744,6 +756,7 @@ class Poller:
         feed_polling_retrieved_count = 0
         feed_polling_failed_count = 0
         feed_polling_stored_count = 0
+        feed_polling_skipped_count = 0
         http_status_code = 0
 
         logger.info(f"== using script {script_path}")
@@ -758,11 +771,14 @@ class Poller:
                 self.p.returncode if self.p and self.p.returncode is not None else -2
             )
             # counts remain 0
-        elif results and len(results) == 3:  # noqa: PLR2004
+        elif results and (len(results) == 3 or len(results) == 4):  # noqa: PLR2004
             try:
                 feed_polling_retrieved_count = int(results[0])
                 feed_polling_failed_count = int(results[1])
                 feed_polling_stored_count = int(results[2])
+                if len(results) == 4:  # noqa: PLR2004
+                    feed_polling_skipped_count = int(results[3])
+
                 if self.p and self.p.returncode == 0:
                     http_status_code = 200
                 elif self.p and self.p.returncode is not None:
@@ -778,6 +794,7 @@ class Poller:
                 feed_polling_retrieved_count = 0  # Reset to be safe
                 feed_polling_failed_count = 0
                 feed_polling_stored_count = 0
+                feed_polling_skipped_count = 0
         else:
             logger.error(
                 f"== [{script_path}] did not return expected output: {results}",
@@ -790,6 +807,7 @@ class Poller:
             feed_polling_retrieved_count,
             feed_polling_failed_count,
             feed_polling_stored_count,
+            feed_polling_skipped_count,
             http_status_code,
         )
 
@@ -800,6 +818,7 @@ class Poller:
         feed_polling_retrieved_count = 0
         feed_polling_failed_count = 0
         feed_polling_stored_count = 0
+        feed_polling_skipped_count = 0
 
         # Check if polling should be skipped
         if self._should_skip_polling():
@@ -814,13 +833,21 @@ class Poller:
                 feed_polling_retrieved_count,
                 feed_polling_failed_count,
                 feed_polling_stored_count,
+                feed_polling_skipped_count,
                 http_status_code,
             ) = self._handle_script_polling(script_path)
         else:
-            retrieved, failed, stored, status_from_poll = _poll_feed(self.feed)
+            (
+                retrieved,
+                failed,
+                stored,
+                skipped,
+                status_from_poll,
+            ) = _poll_feed(self.feed)
             feed_polling_retrieved_count = retrieved
             feed_polling_failed_count = failed
             feed_polling_stored_count = stored
+            feed_polling_skipped_count = skipped
             http_status_code = status_from_poll
 
         poll_end_time = datetime.datetime.now(datetime.UTC)
@@ -831,6 +858,7 @@ class Poller:
         self.retrieved += feed_polling_retrieved_count
         self.failed += feed_polling_failed_count
         self.stored += feed_polling_stored_count
+        self.skipped += feed_polling_skipped_count
 
         FeedPolling.objects.create(
             feed=self.feed,
@@ -840,6 +868,7 @@ class Poller:
             articles_retrieved=feed_polling_retrieved_count,
             articles_failed=feed_polling_failed_count,
             articles_stored=feed_polling_stored_count,
+            articles_skipped=feed_polling_skipped_count,
         )
 
         self.feed.last_polled = poll_end_time  # Use poll_end_time for consistency


### PR DESCRIPTION
This PR adds a `min_length` field to the `Feeds` model, allowing users to specify a minimum content length for articles to be stored. Articles below this threshold are skipped during polling and tracked in a new `articles_skipped` column in the `FeedPolling` table. The logic in `poller.py` and several specific polling scripts has been updated to support this new functionality.

---
*PR created automatically by Jules for task [18170293675534707568](https://jules.google.com/task/18170293675534707568) started by @simevo*