### PR TITLE
Integrate Mypy static type checking

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -309,3 +309,28 @@ tag-latest-docker-images:
     - if: "$CI_DEFAULT_BRANCH == $CI_COMMIT_BRANCH"
       when: on_success
     - when: never
+
+mypy:
+  stage: test
+  image:
+    name: $CI_REGISTRY_IMAGE/backend-test:$TAG
+  variables:
+    POSTGRES_USER: flash
+    POSTGRES_PASSWORD: flash
+    POSTGRES_HOST: db
+    POSTGRES_DB: flash
+    POSTGRES_PORT: 5432
+    DATABASE_URL: postgres://flash:flash@db:5432/flash
+    CELERY_BROKER_URL: redis://redis:6379/0
+    USE_DOCKER: "yes"
+  services:
+    - name: $CI_REGISTRY_IMAGE/postgres:$TAG
+      alias: db
+      variables:
+        POSTGRES_DB: test_flash
+    - name: docker.io/redis:8.8.0-trixie
+      alias: redis
+  before_script:
+    - wait-for-it "${POSTGRES_HOST}:${POSTGRES_PORT}" -t 30
+  script:
+    - mypy flash news poller.py

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -50,9 +50,9 @@ For convenience, you can keep your normal user logged in on Chrome and your supe
 
 ### Type checks
 
-Running type checks with mypy:
+Run static type checks with [mypy](https://www.mypy-lang.org):
 
-    $ mypy flash
+    docker-compose -f docker-compose.local.yml run --rm django mypy flash news poller.py
 
 ### Test coverage
 

--- a/flash/users/forms.py
+++ b/flash/users/forms.py
@@ -7,17 +7,17 @@ from .models import User
 
 
 class UserAdminChangeForm(admin_forms.UserChangeForm):
-    class Meta(admin_forms.UserChangeForm.Meta):  # type: ignore[name-defined]
+    class Meta(admin_forms.UserChangeForm.Meta):
         model = User
 
 
-class UserAdminCreationForm(admin_forms.AdminUserCreationForm):  # type: ignore[name-defined]  # django-stubs is missing the class, thats why the error is thrown: typeddjango/django-stubs#2555
+class UserAdminCreationForm(admin_forms.AdminUserCreationForm):    # django-stubs is missing the class, thats why the error is thrown: typeddjango/django-stubs#2555
     """
     Form for User Creation in the Admin Area.
     To change user signup, see UserSignupForm and UserSocialSignupForm.
     """
 
-    class Meta(admin_forms.UserCreationForm.Meta):  # type: ignore[name-defined]
+    class Meta(admin_forms.UserCreationForm.Meta):
         model = User
         error_messages = {
             "username": {"unique": _("This username has already been taken.")},

--- a/flash/users/tests/factories.py
+++ b/flash/users/tests/factories.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, ClassVar, Optional, cast
 
 from factory import Faker
 from factory import post_generation
@@ -14,7 +14,7 @@ class UserFactory(DjangoModelFactory[User]):
     name = Faker("name")
 
     @post_generation
-    def password(self, create: bool, extracted: Sequence[Any], **kwargs):  # noqa: FBT001
+    def password(instance, create: bool, extracted: Sequence[Any], **kwargs):  # noqa: FBT001
         password = (
             extracted
             if extracted
@@ -27,12 +27,12 @@ class UserFactory(DjangoModelFactory[User]):
                 lower_case=True,
             ).evaluate(None, None, extra={"locale": None})
         )
-        self.set_password(password)
+        cast(Any, instance).set_password(password)
 
     @classmethod
     def _after_postgeneration(cls, instance, create, results=None):
         """Save again the instance if creating and at least one hook ran."""
-        if create and results and not cls._meta.skip_postgeneration_save:
+        if create and results and not getattr(cls._meta, "skip_postgeneration_save", False):
             # Some post-generation hooks ran, and may have modified us.
             instance.save()
 

--- a/flash/users/tests/test_views.py
+++ b/flash/users/tests/test_views.py
@@ -1,3 +1,4 @@
+from typing import cast
 from http import HTTPStatus
 
 import pytest
@@ -85,7 +86,7 @@ class TestUserRedirectView:
 class TestUserDetailView:
     def test_authenticated(self, user: User, rf: RequestFactory):
         request = rf.get("/fake-url/")
-        request.user = UserFactory()
+        request.user = cast(User, UserFactory())
         response = user_detail_view(request, username=user.username)
 
         assert response.status_code == HTTPStatus.OK

--- a/news/api/views.py
+++ b/news/api/views.py
@@ -1,5 +1,6 @@
 # ruff: noqa: E501, PLR2004, PLR0915, C901, PLR0911, PLR0912
 
+from typing import Any, cast
 import html
 import re
 import uuid
@@ -118,7 +119,7 @@ def get_epub(
 
     # create chapters
     cs = []  # chapters
-    fs = {}  # chapters grouped by feed_id
+    fs: dict[int, tuple[Any, ...]] = {}  # chapters grouped by feed_id
     fn = {}  # feed name for each feed_id
     spine = [
         "nav",
@@ -179,7 +180,7 @@ def get_epub(
         spine.append(c)
 
     # define Table Of Contents
-    toc = ()
+    toc: Any = ()
     for f in list(fs.keys()):
         toc = (*toc, (epub.Section(fn[f]), fs[f]))
     book.toc = toc
@@ -408,12 +409,12 @@ class ArticlesView(
                 php,
             )
         return super().create(
-            Request(
+            cast(Any, Request(
                 request.method,
                 request.path,
                 data=modified_data,
                 headers=request.headers,
-            ),
+            )),
             *args,
             **kwargs,
         )
@@ -635,7 +636,7 @@ class ProfileView(
     queryset = Profile.objects.none()
 
     def get_object(self):
-        return self.request.user.profile
+        return cast(Any, self.request.user).profile
 
 
 class UserFeedsView(viewsets.ModelViewSet):
@@ -644,7 +645,7 @@ class UserFeedsView(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
-        return self.queryset.filter(user_id=self.request.user.id)
+        return self.queryset.filter(user_id=cast(int, self.request.user.id))
 
     def create(self, request, *args, **kwargs):
         user_id = request.user.id
@@ -731,13 +732,16 @@ class UserArticleListsView(viewsets.ModelViewSet):
     )
     @action(detail=False, methods=["GET"])
     def me(self, request, *args, **kwargs):
-        data = (
-            UserArticleLists.objects.filter(
-                user_id=request.user.id,
-            )
-            .order_by("-automatic")
-            .annotate(articles_set=ArrayAgg("articles"))
-            .values("id", "name", "automatic", "articles_set", "user")
+        data = cast(
+            list[dict[str, Any]],
+            list(
+                UserArticleLists.objects.filter(
+                    user_id=cast(int, request.user.id),
+                )
+                .order_by("-automatic")
+                .annotate(articles_set=ArrayAgg("articles"))
+                .values("id", "name", "automatic", "articles_set", "user"),
+            ),
         )
         for d in data:
             article_ids = d.pop("articles_set")
@@ -855,13 +859,13 @@ class UserArticleListsView(viewsets.ModelViewSet):
     @action(detail=True)
     def html(self, request, pk=None):
         queryset = UserArticleLists.objects.filter(
-            user_id=request.user.id,
+            user_id=cast(int, request.user.id),
         )
         article_list_obj = get_object_or_404(queryset, pk=pk)
         article_list = article_list_obj.articles.all()
         article_count = article_list.count()
         total_estimated_reading_time = ""
-        articles_data = []
+        articles_data: Any = []
         if article_count > 0:
             articles_data = ArticlesCombined.objects.filter(id__in=article_list)
             for article in articles_data:
@@ -889,13 +893,13 @@ class UserArticleListsView(viewsets.ModelViewSet):
     @action(detail=True)
     def pdf(self, request, pk=None):
         queryset = UserArticleLists.objects.filter(
-            user_id=request.user.id,
+            user_id=cast(int, request.user.id),
         )
         user_list = get_object_or_404(queryset, pk=pk)
         article_list = user_list.articles.all()
         article_count = article_list.count()
         total_estimated_reading_time = ""
-        articles_data = []
+        articles_data: Any = []
         if article_count > 0:
             articles_data = ArticlesCombined.objects.filter(id__in=article_list)
             for article in articles_data:
@@ -938,13 +942,13 @@ class UserArticleListsView(viewsets.ModelViewSet):
     @action(detail=True)
     def epub(self, request, pk=None):
         queryset = UserArticleLists.objects.filter(
-            user_id=request.user.id,
+            user_id=cast(int, request.user.id),
         )
         user_list = get_object_or_404(queryset, pk=pk)
         article_list = user_list.articles.all()
         article_count = article_list.count()
         total_estimated_reading_time = ""
-        articles_data = []
+        articles_data: Any = []
         if article_count > 0:
             articles_data = ArticlesCombined.objects.filter(id__in=article_list)
             for article in articles_data:

--- a/news/management/commands/find_duplicates.py
+++ b/news/management/commands/find_duplicates.py
@@ -78,8 +78,8 @@ class Command(BaseCommand):
         Process articles to find initial duplicate sets.
         Returns a list of sets, where each set contains IDs of duplicate articles.
         """
-        duplicate_sets = []
-        processed_article_ids = set()
+        duplicate_sets: list[set[int]] = []
+        processed_article_ids: set[int] = set()
         article_count = articles_to_process.count()
 
         for i, source_article in enumerate(articles_to_process):

--- a/news/models.py
+++ b/news/models.py
@@ -265,7 +265,7 @@ class UserArticleLists(models.Model):
         on_delete=models.CASCADE,
     )
     name = models.TextField()
-    articles = models.ManyToManyField(Articles, through="ArticleLists")
+    articles: models.ManyToManyField[Articles, 'ArticleLists'] = models.ManyToManyField(Articles, through='ArticleLists')
     automatic = models.BooleanField(default=False)
 
     class Meta:

--- a/news/poll_119.py
+++ b/news/poll_119.py
@@ -1,3 +1,4 @@
+# mypy: ignore-errors
 #!/usr/bin/env python3
 
 import datetime

--- a/news/poll_189.py
+++ b/news/poll_189.py
@@ -1,3 +1,4 @@
+# mypy: ignore-errors
 #!/usr/bin/env python3
 
 import datetime

--- a/news/poll_94.py
+++ b/news/poll_94.py
@@ -1,3 +1,4 @@
+# mypy: ignore-errors
 #!/usr/bin/env python3
 
 import datetime

--- a/news/poll_96.py
+++ b/news/poll_96.py
@@ -1,3 +1,4 @@
+# mypy: ignore-errors
 #!/usr/bin/env python3
 
 import datetime

--- a/news/services.py
+++ b/news/services.py
@@ -1,8 +1,10 @@
+from typing import ClassVar, Optional
 from sentence_transformers import SentenceTransformer
 
 
 class TextEmbeddingService:
-    _instance = None
+    _instance: ClassVar[Optional['TextEmbeddingService']] = None
+    model: SentenceTransformer
 
     def __new__(cls):
         if cls._instance is None:

--- a/news/tasks.py
+++ b/news/tasks.py
@@ -1,3 +1,4 @@
+from typing import Any, cast
 import datetime
 import html
 import logging
@@ -149,7 +150,7 @@ def embed(n):
                 """,
             )
             before = cur.fetchone()
-            logger.info(f"  processed articles before: {before['count']}")
+            logger.info(f"  processed articles before: {cast(Any, before)[0]}")
 
             start_time = time.perf_counter()
             cur.execute(
@@ -249,7 +250,7 @@ def embed(n):
                 """,
             )
             after = cur.fetchone()
-            logger.info(f"  processed articles after: {after[0]}")
+            logger.info(f"  processed articles after: {cast(Any, after)[0]}")
             return len(articles)
 
 

--- a/news/tests/test_api_views.py
+++ b/news/tests/test_api_views.py
@@ -1,10 +1,12 @@
 # ruff: noqa: PLR2004, S106, S311
 import random
 import string
+from typing import Any
 from unittest import mock
 
 from django.core.cache import cache
 from django.urls import reverse
+from datetime import timedelta
 from django.utils import timezone
 from rest_framework.test import APITestCase
 
@@ -23,7 +25,7 @@ def create_articles(feed, n):
             title=f"Article F1 {i+1}",
             content_original=f"Content F1 {i+1}",
             url=f"http://example.com/article_f1_{i+1}",
-            stamp=timezone.now() - timezone.timedelta(hours=410 - i),
+            stamp=timezone.now() - timedelta(hours=410 - i),
         )
         article_data = ArticlesData.objects.get(id=article)
         # ArticlesData is created by the trogger; tweak data:
@@ -39,6 +41,11 @@ def create_articles(feed, n):
 
 
 class ArticleAPITests(APITestCase):
+    user: User
+    feed1: Feeds
+    feed2: Feeds
+    articles_feed1: list[Articles]
+    articles_feed2: list[Articles]
     @classmethod
     def setUpTestData(cls):
         cls.user = User.objects.create_user(
@@ -111,7 +118,7 @@ class ArticleAPITests(APITestCase):
             title="Article New",
             content_original="Content New",
             url="http://example.com/article_new",
-            stamp=timezone.now() + timezone.timedelta(seconds=1),  # Ensure it's newer
+            stamp=timezone.now() + timedelta(seconds=1),  # Ensure it's newer
         )
 
         # 3. Call the poll task. This task is expected to clear the cache.

--- a/news/translate.py
+++ b/news/translate.py
@@ -1,24 +1,24 @@
 # ruff: noqa: S314, E501, UP031
 import json
 from pathlib import Path
+from typing import Any
 
 import requests
 
 base_language = "it"
 SEPARATOR = "||||||"
 
+_secret_cache: dict[str, str] = {}
 
-def secret(path):
-    if secret.cached.get(path, "") == "":
+
+def secret(path: str) -> str:
+    if _secret_cache.get(path, "") == "":
         with Path(path).open() as secret_file:
             encoded_secret = secret_file.read()
-        secret.cached[path] = (
+        _secret_cache[path] = (
             encoded_secret.strip()
         )  # Ensure no leading/trailing whitespace
-    return secret.cached[path]
-
-
-secret.cached = {}
+    return _secret_cache[path]
 
 
 class TranslationError(Exception):

--- a/poller.py
+++ b/poller.py
@@ -10,7 +10,7 @@ import logging
 import subprocess
 import time
 import urllib
-from typing import Any
+from typing import Any, cast
 from typing import TypedDict
 
 import aiohttp
@@ -110,25 +110,35 @@ async def retrieve(
     failed = 0
     stored = 0
     url = entry["link"]
+    decoded_content = ""
     if feed.incomplete and entry["link"]:
-        content, retrieved, failed = await download_content(
+        content_bytes, retrieved, failed = await download_content(
             client,
             entry,
             feed,
             verbose=verbose,
         )
+        decoded_content = content_bytes.decode()
     elif "content" in entry:
-        content = b"" if isinstance(entry["content"][0], bytes) else ""
-        for c in entry["content"]:
-            content += c.value
+        if isinstance(entry["content"][0].value, bytes):
+            content_bytes = b""
+            for c in entry["content"]:
+                content_bytes += c.value
+            decoded_content = content_bytes.decode()
+        else:
+            content_str = ""
+            for c in entry["content"]:
+                content_str += c.value
+            decoded_content = content_str
     elif "summary" in entry:
-        content = entry["summary"]
+        content_sum = entry["summary"]
+        decoded_content = (
+            content_sum.decode() if isinstance(content_sum, bytes) else content_sum
+        )
     else:
         failed += 1
         logger.error(f"=== url {url} has no content and no summary")
         return (retrieved, failed, stored)
-
-    decoded_content = content.decode() if isinstance(content, bytes) else content
 
     if feed.salt_url:
         # add some cruft to the urls so that they are unique
@@ -341,16 +351,19 @@ def normalize_content(
         "sup",
     ]
     for s in top.children:
-        if isinstance(s, NavigableString) or s.name in inline_tags:
+        if isinstance(s, NavigableString):
             current_paragraph.append(copy.copy(s))
-        elif s.name == "p":
-            current_paragraph = copy.copy(s)
-            new_soup.append(current_paragraph)
-        else:
-            current_paragraph = new_soup.new_tag("p")
-            t = copy.copy(s)
-            new_soup.append(t)
-            t.wrap(current_paragraph)
+        elif isinstance(s, Tag):
+            if s.name in inline_tags:
+                current_paragraph.append(copy.copy(s))
+            elif s.name == "p":
+                current_paragraph = copy.copy(s)
+                new_soup.append(current_paragraph)
+            else:
+                current_paragraph = new_soup.new_tag("p")
+                t = copy.copy(s)
+                new_soup.append(t)
+                t.wrap(current_paragraph)
 
     # get rid of br's
     fragment = "".join(str(c) for c in new_soup.contents)
@@ -363,8 +376,10 @@ def normalize_content(
             p.extract()
 
     # flatten
-    soup.html.body.unwrap()
-    soup.html.unwrap()
+    if soup.html:
+        if soup.html.body:
+            soup.html.body.unwrap()
+        soup.html.unwrap()
 
     prettified = soup.prettify(formatter="html5")
     decoded = (
@@ -378,7 +393,8 @@ def clean(s: str) -> str:
     if s:
         t = html.unescape(s)
         u = lxml.html.fromstring(t)
-        return u.text_content()
+        text = cast(Any, u).text_content()
+        return str(text) if text is not None else ""
     return s
 
 
@@ -387,7 +403,7 @@ class ArticleDict(TypedDict, total=False):
     content: str
     feed_id: int
     language: str
-    stamp: int
+    stamp: str | datetime.datetime | datetime.date
     title: str
     url: str
 

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -33,3 +33,8 @@ django-debug-toolbar==7.0.0  # https://github.com/jazzband/django-debug-toolbar
 django-extensions==4.1  # https://github.com/django-extensions/django-extensions
 django-coverage-plugin==3.2.2  # https://github.com/nedbat/django_coverage_plugin
 pytest-django==4.12.0  # https://github.com/pytest-dev/pytest-django
+types-beautifulsoup4==4.12.0.20250516
+types-requests==2.33.0.20260518
+types-pytz==2026.2.0.20260518
+types-python-dateutil==2.9.0.20260518
+lxml-stubs==0.5.1


### PR DESCRIPTION
This PR implements static type checking for the Python codebase using mypy.

Key changes:
1.  **CI/CD Integration**: A new `mypy` job has been added to the `.gitlab-ci.yml` pipeline in the `test` stage. It utilizes the `backend-test` image and depends on `postgres` and `redis` services to correctly initialize the Django environment for the `mypy-django-plugin`.
2.  **Documentation**: Updated `docs/DEVELOPING.md` with instructions and the Docker-based command for running static type checks locally.
3.  **Dependency Management**: Added necessary type stubs (`types-beautifulsoup4`, `types-requests`, `types-pytz`, etc.) to `requirements/local.txt`.
4.  **Codebase Fixes**:
    - Refactored `news/translate.py` to handle the `secret` function cache in a type-safe manner.
    - Fixed type mismatches and attribute errors in `poller.py` related to `BeautifulSoup` and `lxml`.
    - Added type annotations to Django Models (ManyToManyField) and Views.
    - Used `cast` in `news/api/views.py` to handle dynamic dictionary keys from `.values()` queries and resolve `User | AnonymousUser` ambiguity.
5.  **Test Suite Adjustments**: Added class-level type annotations to test classes in `news/tests/test_api_views.py` and improved `factory-boy` usage in `flash/users/tests/factories.py` to satisfy mypy.
6.  **Legacy Poller Scripts**: Added `# mypy: ignore-errors` to `news/poll_*.py` files as agreed, allowing for a relaxed approach to these specific scripts.

---
*PR created automatically by Jules for task [3900339865098081987](https://jules.google.com/task/3900339865098081987) started by @simevo*